### PR TITLE
Adding PHP 8.1 Compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   "version": "1.0.0",
   "minimum-stability": "stable",
   "require": {
-    "php": "~7.2.0||~7.3.0||~7.4.0",
+    "php": "~7.2.0||~7.3.0||~7.4.0||~8.0.0||~8.1.0",
     "magento/framework": "*",
     "magento/module-store": "*"
   },


### PR DESCRIPTION
Updating the composer.json to allow installing the adapter library to Magento 2.4.5 which requires PHP 8.1