### PR TITLE
Removing Composer Version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
       "email": "b.w.kubicki@gmail.com"
     }
   ],
-  "version": "1.0.0",
   "minimum-stability": "stable",
   "require": {
     "php": "~7.2.0||~7.3.0||~7.4.0||~8.0.0||~8.1.0",


### PR DESCRIPTION
Removing the version from composer so that we can use the tags without having to update the `composer.json` as well.