### PR TITLE
Adding PHP 8.2 Compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   ],
   "minimum-stability": "stable",
   "require": {
-    "php": "~7.2.0||~7.3.0||~7.4.0||~8.0.0||~8.1.0",
+    "php": "~7.2.0||~7.3.0||~7.4.0||~8.0.0||~8.1.0||~8.2.0",
     "magento/framework": "*",
     "magento/module-store": "*"
   },


### PR DESCRIPTION
Updating the composer.json to allow installing the adapter library to Magento 2.4.7 which requires PHP 8.2